### PR TITLE
Mobile table and stat text wrapping.

### DIFF
--- a/src/pages/vision/virtual-care/index.js
+++ b/src/pages/vision/virtual-care/index.js
@@ -85,7 +85,7 @@ class VirtualCareFeature extends Component {
             </div>
           </div>
 
-          <div className="pad-vertical--double">
+          <div className="pad-vertical--double vpc">
             <table width="100%" className="virtual-diagram">
               <tr className="text--gray">
                 <td width="20%">Reason for Visit</td>

--- a/src/styles/vision/_virtual-care-feature.scss
+++ b/src/styles/vision/_virtual-care-feature.scss
@@ -11,7 +11,7 @@
       background-color: #f9f9f9;
     }
     td {
-      padding: 10px 0;
+      padding: 10px 5px;
     }
     td:first-child {
       padding-left: 20px;
@@ -35,6 +35,10 @@
     }
   }
 
+  td {
+    padding-right: 5px;
+  }
+
   h3 {
     &.text--lg {
       font-size: 20px;
@@ -50,6 +54,10 @@
 
   .pad-vertical--double:first-child {
     padding-bottom: 0;
+  }
+
+  .pad-vertical--double.vpc {
+    overflow-x: auto;
   }
 
   .pure-u-lg-1-2 {
@@ -74,6 +82,7 @@
   .number--lg {
     font-size: 80px;
     font-family: 'Adobe-Jenson-Pro', 'Georgia', serif;
+    line-height: 80px;
   }
 
   .text-right,


### PR DESCRIPTION
Updated css
- big diagram table is the only section that horizontally scrolls and not the entire page
- line height for the stats no longer overlaps itself when wrapping