### PR TITLE
show case studies and features

### DIFF
--- a/src/components/layouts/case-study-layout.js
+++ b/src/components/layouts/case-study-layout.js
@@ -21,16 +21,19 @@ import {
 
 import config from '../../../config'
 
-const CaseStudyLayout = ({ data, children }) => {
-  const { mdx } = data
+const CaseStudyLayout = ({ data: caseStudies, children }) => {
+  const { mdx } = caseStudies
 
   if (!mdx || !children) {
     return
   }
 
-  const caseStudiesWithFeatures = concatCaseStudiesAndFeatures(data, false)
+  const caseStudiesWithFeatures = concatCaseStudiesAndFeatures({
+    caseStudies,
+    filterFeatures: false,
+  })
 
-  const caseStudy = findCaseStudyById(data, mdx.id)
+  const caseStudy = findCaseStudyById(caseStudies, mdx.id)
 
   const meta = [
     {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -50,11 +50,11 @@ export function extractWorkItemLinkDetails(item) {
   }
 }
 
-export function concatCaseStudiesAndFeatures(
+export function concatCaseStudiesAndFeatures({
   caseStudies,
   selectedCategoryId = "all",
   filterFeatures = true
-) {
+}) {
   const validCategories = Object.keys(caseStudiesOrder); // Get valid categories from case-study-order.json
   const categoryOrder = caseStudiesOrder[selectedCategoryId] || [];
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -47,7 +47,7 @@ class IndexPage extends Component {
   constructor(props) {
     super(props)
 
-    const workItems = concatCaseStudiesAndFeatures(props.data).slice(0, 4)
+    const workItems = concatCaseStudiesAndFeatures({ caseStudies: props.data }).slice(0, 4)
 
     this.state = {
       image: null,

--- a/src/pages/work.js
+++ b/src/pages/work.js
@@ -100,13 +100,13 @@ class WorkPage extends Component {
     // Get category data for the selected category
     const categoryData = headerData[categoryId] || headerData['all'] || {};
     const heroImages = categoryData.heroImages || [];
-  
+
     // Select a random hero image from the category (fallback to a default image if none exist)
     const heroImage =
       heroImages.length > 0
         ? heroImages[Math.floor(Math.random() * heroImages.length)]
         : '/images/work/dr-emily.jpg'; // Replace with a valid default image path
-    
+
     // Create the frontmatter dynamically
     const frontmatter = {
       metaTitle: 'Case Studies by UX Design Agency GoInvo',
@@ -116,7 +116,7 @@ class WorkPage extends Component {
       title: 'Design that Delivers', // Fallback title
       subtitle: 'Real projects, real users, real business outcomes.'
     }
-  
+
     return { categoryData, heroImages, frontmatter, heroImage };
   }
 
@@ -135,9 +135,12 @@ class WorkPage extends Component {
       CATEGORIES_LIST.find(cat => cat.id === categoryId) ||
       props.selectedCategory ||
       allCategory;
-    
+
     // Get work items for the selected category
-    const workItems = concatCaseStudiesAndFeatures(props.data, selectedCategory.id);
+    const workItems = concatCaseStudiesAndFeatures({
+      caseStudies: props.data,
+      selectedCategoryId: selectedCategory.id
+    });
 
     // Get category data, hero images, and frontmatter
     const { categoryData, heroImages, frontmatter, heroImage } =
@@ -195,7 +198,10 @@ class WorkPage extends Component {
     this.setState(
       {
         selectedCategory: cat,
-        workItems: concatCaseStudiesAndFeatures(this.props.data, cat.id),
+        workItems: concatCaseStudiesAndFeatures({
+          caseStudies: this.props.data,
+          selectedCategoryId: cat.id,
+        }),
         categoriesCollapsed: this.state.categoriesStuck ? true : false,
         categoryData,
         frontmatter,


### PR DESCRIPTION
instead of passing parameters to concatCaseStudies, passing an object. Otherwise, we can unset filterFeatures from false, because we don't want them filtered on the case study layout